### PR TITLE
Add GEO/AEO Tracker - open-source AI visibility dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@
 | [Tugan.ai](https://www.tugan.ai/?ref=awe50meAI) |     Enter a URL or TOPIC To Generate Your Marketing Emails Instantly With AI  |
 | [Marketing Co-pilot AI](https://marketingcopilotai.com/?ref=awe50meAI) | The Better Way to Do Marketing |
 | [Domains GPT](https://oneword.domains/domains-gpt/?ref=awe50meAI) | Generate brandable & memorable domain names using AI. Powered by OpenAI and Vercel Edge Functions. |
+| [GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker) | Open-source, local-first AI visibility dashboard. Track brand mentions across ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok. BYOK, self-hosted, $0/month, with visibility scoring, citation analysis, and competitor battlecards. |
 
 ## design tools
 | Awesome | Description |


### PR DESCRIPTION
## New entry: GEO/AEO Tracker

Adding to the **commerce & marketing tools** section.

**[GEO/AEO Tracker](https://github.com/danishashko/geo-aeo-tracker)**  Open-source, local-first AI visibility intelligence dashboard.

### Highlights:
- Tracks brand mentions across **ChatGPT, Perplexity, Gemini, Copilot, Google AI Overview, and Grok** (6 platforms)
- **Open-source** (MIT license) - completely free to use
- BYOK - $0/month operational cost vs competitors at $200-500/month
- 12-tab dashboard with visibility scoring, citation analysis, and competitor battlecards
- Live demo: https://llm-tracker-three.vercel.app/

Great fit for the AI marketing/commerce section as an open-source tool for tracking AI search visibility.