### PR TITLE
Add DoaCam to Conversational AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 | [alicent](https://alicent.ai/?ref=awe50meAI) |     A Gorgeous Extension for ChatGPT  |
 | [godmode](https://godmode.space/?ref=awe50meAI) |   |
 | [PageLines](https://www.pagelines.com/?ref=awe50meAI) | AI Agents to Enhance Your Website |
-| [DoaCam](https://doacam.com) | A 3D AI avatar you can video call — real-time voice, camera vision, persistent memory. Free, no sign-up, runs in the browser. |
+| [DoaCam](https://doacam.com/?ref=awe50meAI) | AI video companion with a 3D avatar that sees you through your camera, talks in real time, and remembers you across sessions. Browser-based, no sign-up required. |
 
 ## All-in-one tools
 | Awesome | Description |

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 | [alicent](https://alicent.ai/?ref=awe50meAI) |     A Gorgeous Extension for ChatGPT  |
 | [godmode](https://godmode.space/?ref=awe50meAI) |   |
 | [PageLines](https://www.pagelines.com/?ref=awe50meAI) | AI Agents to Enhance Your Website |
+| [DoaCam](https://doacam.com) | A 3D AI avatar you can video call — real-time voice, camera vision, persistent memory. Free, no sign-up, runs in the browser. |
 
 ## All-in-one tools
 | Awesome | Description |


### PR DESCRIPTION
## Summary
- Adds [DoaCam](https://doacam.com) to the **Conversational AI** section
- DoaCam is an AI video companion with a 3D avatar that sees you through your camera, talks in real time, and remembers you across sessions. Browser-based, no sign-up required.
- Follows the existing table format with the ref tracking parameter